### PR TITLE
Process SeekResponse in C++ client

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -1146,6 +1146,27 @@ void ClientConnection::handleIncomingCommand() {
                     break;
                 }
 
+                case BaseCommand::SEEK_RESPONSE: {
+                    const CommandSeekResponse& response = incomingCmd_.seekresponse();
+                    LOG_DEBUG(cnxString_ << "Received seek response from server. req_id: "
+                                         << response.request_id());
+                    Lock lock(mutex_);
+                    auto it = pendingSeekRequests_.find(response.request_id());
+                    if (it != pendingSeekRequests_.end()) {
+                        Promise<Result, MessageId> seekPromise = it->second;
+                        lock.unlock();
+                        const auto& data = response.messageiddata();
+                        MessageId messageId(data.partition(), data.ledgerid(), data.entryid(),
+                                            data.batch_index());
+                        seekPromise.setValue(messageId);
+                    } else {
+                        lock.unlock();
+                        LOG_WARN("SeekResponse command - Received unknown request id from server: "
+                                 << response.request_id());
+                    }
+                    break;
+                }
+
                 default: {
                     LOG_WARN(cnxString_ << "Received invalid message from server");
                     close();
@@ -1334,6 +1355,33 @@ Future<Result, ResponseData> ClientConnection::sendRequestWithId(SharedBuffer cm
     return requestData.promise.getFuture();
 }
 
+Future<Result, MessageId> ClientConnection::sendSeekRequestWithId(SharedBuffer cmd, int requestId) {
+    Promise<Result, MessageId> promise;
+    Lock lock(mutex_);
+
+    if (isClosed()) {
+        lock.unlock();
+        promise.setFailed(ResultNotConnected);
+        return promise.getFuture();
+    }
+
+    SeekRequestData requestData;
+    requestData.timer = executor_->createDeadlineTimer();
+    requestData.timer->expires_from_now(operationsTimeout_);
+    auto self = shared_from_this();
+    requestData.timer->async_wait([this, self, &requestData](const boost::system::error_code& ec) {
+        if (!ec) {
+            requestData.promise.setFailed(ResultTimeout);
+        }
+    });
+
+    pendingSeekRequests_.emplace(requestId, promise);
+    lock.unlock();
+
+    sendCommand(cmd);
+    return promise.getFuture();
+}
+
 void ClientConnection::handleRequestTimeout(const boost::system::error_code& ec,
                                             PendingRequestData pendingRequestData) {
     if (!ec) {
@@ -1408,6 +1456,7 @@ void ClientConnection::close() {
     auto pendingConsumerStatsMap = std::move(pendingConsumerStatsMap_);
     auto pendingGetLastMessageIdRequests = std::move(pendingGetLastMessageIdRequests_);
     auto pendingGetNamespaceTopicsRequests = std::move(pendingGetNamespaceTopicsRequests_);
+    auto pendingSeekRequests = std::move(pendingSeekRequests_);
 
     numOfPendingLookupRequest_ = 0;
 
@@ -1449,6 +1498,9 @@ void ClientConnection::close() {
         kv.second.setFailed(ResultConnectError);
     }
     for (auto& kv : pendingGetNamespaceTopicsRequests) {
+        kv.second.setFailed(ResultConnectError);
+    }
+    for (auto& kv : pendingSeekRequests) {
         kv.second.setFailed(ResultConnectError);
     }
 }

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -143,6 +143,8 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
      */
     Future<Result, ResponseData> sendRequestWithId(SharedBuffer cmd, int requestId);
 
+    Future<Result, MessageId> sendSeekRequestWithId(SharedBuffer cmd, int requestId);
+
     const std::string& brokerAddress() const;
 
     const std::string& cnxString() const;
@@ -167,6 +169,11 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     struct LookupRequestData {
         LookupDataResultPromisePtr promise;
+        DeadlineTimerPtr timer;
+    };
+
+    struct SeekRequestData {
+        Promise<Result, MessageId> promise;
         DeadlineTimerPtr timer;
     };
 
@@ -304,6 +311,9 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     typedef std::map<long, Promise<Result, NamespaceTopicsPtr>> PendingGetNamespaceTopicsMap;
     PendingGetNamespaceTopicsMap pendingGetNamespaceTopicsRequests_;
+
+    typedef std::map<long, Promise<Result, MessageId>> PendingSeekRequestsMap;
+    PendingSeekRequestsMap pendingSeekRequests_;
 
     std::mutex mutex_;
     typedef std::unique_lock<std::mutex> Lock;


### PR DESCRIPTION
### Motivation

Since the Server's response has changed, the C++ client's `seekAsync` doesn't work. We need to process the `SeekResponse` in C++ client.

### Modifications

- Process SeekResponse in `ClientConnection` and pass the response to consumer.
- Set the consumer's `seekMessageId_` to record the message id from the SeekResponse.