### PR TITLE
[fix][broker] fix the wrong type and  default value of maxUnackedMessagesPerSubscriptionOnBrokerBlocked

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -375,8 +375,8 @@ public class BrokerService implements Closeable {
         if (pulsar.getConfiguration().getMaxUnackedMessagesPerBroker() > 0
                 && pulsar.getConfiguration().getMaxUnackedMessagesPerSubscriptionOnBrokerBlocked() > 0.0) {
             this.maxUnackedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerBroker();
-            this.maxUnackedMsgsPerDispatcher = (int) ((maxUnackedMessages
-                    * pulsar.getConfiguration().getMaxUnackedMessagesPerSubscriptionOnBrokerBlocked()) / 100);
+            this.maxUnackedMsgsPerDispatcher = (int) (maxUnackedMessages
+                    * pulsar.getConfiguration().getMaxUnackedMessagesPerSubscriptionOnBrokerBlocked());
             log.info("Enabling per-broker unack-message limit {} and dispatcher-limit {} on blocked-broker",
                     maxUnackedMessages, maxUnackedMsgsPerDispatcher);
             // block misbehaving dispatcher by checking periodically

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -692,8 +692,8 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
         try {
             final int waitMills = 500;
             final int maxUnAckPerBroker = 200;
-            final double unAckMsgPercentagePerDispatcher = 10;
-            int maxUnAckPerDispatcher = (int) ((maxUnAckPerBroker * unAckMsgPercentagePerDispatcher) / 100); // 200 *
+            final double unAckMsgPercentagePerDispatcher = 0.1;
+            int maxUnAckPerDispatcher = (int) (maxUnAckPerBroker * unAckMsgPercentagePerDispatcher); // 200 *
                                                                                                              // 10% = 20
                                                                                                              // messages
             pulsar.getConfiguration().setMaxUnackedMessagesPerBroker(maxUnAckPerBroker);
@@ -907,8 +907,8 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
                 .getMaxUnackedMessagesPerSubscriptionOnBrokerBlocked();
         try {
             final int maxUnAckPerBroker = 200;
-            final double unAckMsgPercentagePerDispatcher = 10;
-            int maxUnAckPerDispatcher = (int) ((maxUnAckPerBroker * unAckMsgPercentagePerDispatcher) / 100); // 200 *
+            final double unAckMsgPercentagePerDispatcher = 0.1;
+            int maxUnAckPerDispatcher = (int) (maxUnAckPerBroker * unAckMsgPercentagePerDispatcher); // 200 *
                                                                                                              // 10% = 20
                                                                                                              // messages
             pulsar.getConfiguration().setMaxUnackedMessagesPerBroker(maxUnAckPerBroker);


### PR DESCRIPTION
This PR is for running tests for upstream PR https://github.com/apache/pulsar/pull/21765.

<!-- Before creating this PR, please ensure that the fork https://github.com/aloyszhang/pulsar is up to date with https://github.com/apache/pulsar -->